### PR TITLE
Fix dropdown input

### DIFF
--- a/app/assets/scripts/context/qs-state-schema.js
+++ b/app/assets/scripts/context/qs-state-schema.js
@@ -17,7 +17,7 @@ export const castByFilterType = (type) => {
     case BOOL:
       return Boolean;
     case DROPDOWN:
-      return ({ name, id }) => id;
+      return (value) => value?.id || value; // value might be object or string
     case MULTI:
     case TEXT:
       return String;


### PR DESCRIPTION
## What I am changing

Users flagged a bug in the Wind Module.

> Zones are only returned for the default Turbine Type [Economics tab]; for any other choice, the tool does not generate zones or the grid.

I am able to reproduce this issue, having tested for Algeria and Kenya, and with the "boundary" grid setting.

This PR fix the dropdown input.

## How I did it

Function `castByFilterType` sometimes might receive an object or a string, but was only able to receive objects. Now it can receive both.

## How you can test it

Run locally, open any country, select onshore wind, change turbine type and click button to generate zones, which should be returned successfully. Repeat with other combination of resource types and countries.

## Related Issues

None.


cc @LanesGood @olafveerman 